### PR TITLE
fix @named variable in the delete client requestLine

### DIFF
--- a/src/main/java/com/commercehub/sensu/api/SensuApi.java
+++ b/src/main/java/com/commercehub/sensu/api/SensuApi.java
@@ -75,7 +75,7 @@ public interface SensuApi {
      *
      * @param client the client name
      */
-    @RequestLine("DELETE /clients/{name}")
+    @RequestLine("DELETE /clients/{client}")
     void deleteClient(@Named("client") String client) throws SensuNotFoundException, SensuErrorException;
 
     /**


### PR DESCRIPTION
Fix a quick bug in the API where there is a mismatch between the named argument and the token used in the requestLine.